### PR TITLE
Fix enumeration bug in utility function

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -17,9 +17,9 @@ def print_metrics(metrics: dict, prefix: str = ""):
 
 
 def save_images(results, save_dir, prefix="infer", ext="png"):
-    for i, datasets in enumerate(iterable=results):
+    for i, datasets in enumerate(results):
         save_path = make_dirs(path=f"{save_dir}/batch{i+1}")
-        for ii, batch in enumerate(iterable=datasets):
+        for ii, batch in enumerate(datasets):
             save_image(
                 tensor=batch,
                 fp=save_path / f"{prefix}_{ii:04d}.{ext}",


### PR DESCRIPTION
## Summary
- fix incorrect keyword arguments when enumerating results in `save_images`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848db363c7c83269c8d9cd0a3804b26